### PR TITLE
Update maven repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ group = "com.fengsheng"
 version = "1.0-SNAPSHOT"
 
 repositories {
-    maven("https://maven.aliyun.com/repository/public")
+    maven("https://mirrors.cloud.tencent.com/nexus/repository/maven-public/")
     mavenCentral()
 }
 


### PR DESCRIPTION
更换maven镜像为腾讯云，以解决arm架构下无法下载protoc的问题