### PR TITLE
房间号信息增加房间号字段

### DIFF
--- a/src/main/kotlin/GameExecutor.kt
+++ b/src/main/kotlin/GameExecutor.kt
@@ -85,9 +85,35 @@ object GameExecutor {
         return TimeWheel.newTimeout({ post(game, callback) }, delay, unit)
     }
 
-    fun newGame(lastTotalPlayerCount: Int): Game {
-        val id = Game.increaseId.incrementAndGet()
-        val actorRef = system.actorOf(Props.create(GameActor::class.java), "game-$id")
-        return Game(id, lastTotalPlayerCount, actorRef)
+    fun getGame(id: Int, playerCount: Int): Game {
+        val count =
+            if (playerCount == 0) Config.TotalPlayerCount
+            else playerCount.coerceIn(5..9)
+        // 找房间
+        if (id == 0) {
+            val game = Game.gameCache.values.shuffled().find { !it.isStarted }
+            if (game != null) return game
+        } else {
+            val game = Game.gameCache[id]
+            if (game != null) return game
+        }
+        // 新建房间
+        val newId = if (id == 0) {
+            var id0: Int
+            while (true) {
+                id0 = Game.increaseId.incrementAndGet()
+                if (!Game.gameCache.containsKey(id0)) break
+            }
+            id0
+        } else {
+            id
+        }
+        val actorRef = system.actorOf(Props.create(GameActor::class.java), "game-$newId")
+        val game = Game(newId, count, actorRef)
+        if (Game.gameCache.putIfAbsent(newId, game) != null) {
+            game.actorRef.tell(StopGameActor(), ActorRef.noSender())
+            throw IllegalStateException("游戏ID冲突")
+        }
+        return game
     }
 }

--- a/src/main/kotlin/GameExecutor.kt
+++ b/src/main/kotlin/GameExecutor.kt
@@ -88,6 +88,7 @@ object GameExecutor {
     fun getGame(id: Int, playerCount: Int): Game {
         val count =
             if (playerCount == 0) Config.TotalPlayerCount
+            else if (Config.IsGmEnable) playerCount.coerceIn(2..9)
             else playerCount.coerceIn(5..9)
         // 找房间
         if (id == 0) {

--- a/src/main/kotlin/gm/Addrobot.kt
+++ b/src/main/kotlin/gm/Addrobot.kt
@@ -9,15 +9,16 @@ class Addrobot : Function<Map<String, String>, Any> {
         return try {
             var count = form["count"]?.toInt() ?: 0
             count = if (count > 0) count else 99
-            val g = Game.newGame
-            GameExecutor.post(g) {
-                count = min(count, g.players.count { it == null })
-                for (i in 0 until count) {
-                    if (g.isStarted) break
-                    val robotPlayer: Player = RobotPlayer()
-                    robotPlayer.playerName = Player.randPlayerName(g)
-                    robotPlayer.game = g
-                    g.onPlayerJoinRoom(robotPlayer, Statistics.totalPlayerGameCount.random())
+            for (g in Game.gameCache.values) {
+                GameExecutor.post(g) {
+                    count = min(count, g.players.count { it == null })
+                    for (i in 0 until count) {
+                        if (g.isStarted) break
+                        val robotPlayer: Player = RobotPlayer()
+                        robotPlayer.playerName = Player.randPlayerName(g)
+                        robotPlayer.game = g
+                        g.onPlayerJoinRoom(robotPlayer, Statistics.totalPlayerGameCount.random())
+                    }
                 }
             }
             "{\"msg\": \"success\"}"

--- a/src/main/kotlin/gm/Forceend.kt
+++ b/src/main/kotlin/gm/Forceend.kt
@@ -8,7 +8,10 @@ class Forceend : Function<Map<String, String>, Any> {
     override fun apply(form: Map<String, String>): Any {
         return try {
             Game.gameCache.values.toList().forEach {
-                GameExecutor.post(it) { it.end(null, null, true) }
+                GameExecutor.post(it) {
+                    if (it.isStarted && !it.isEnd)
+                        it.end(null, null, true)
+                }
             }
             "{\"result\": true}"
         } catch (e: NullPointerException) {

--- a/src/main/kotlin/handler/JoinRoomTos.kt
+++ b/src/main/kotlin/handler/JoinRoomTos.kt
@@ -140,6 +140,7 @@ class JoinRoomTos : ProtoHandler {
                     scores.add(score)
                 }
                 notice = "${Config.Notice.get()}\n\n${Statistics.rankList25.get()}"
+                roomId = newGame.id
             })
         }
     }

--- a/src/main/kotlin/handler/JoinRoomTos.kt
+++ b/src/main/kotlin/handler/JoinRoomTos.kt
@@ -69,7 +69,7 @@ class JoinRoomTos : ProtoHandler {
             player.sendErrorMessage("房间已满，请稍后再试")
             return
         }
-        val newGame = Game.newGame
+        val newGame = GameExecutor.getGame(pb.roomId, pb.playerCount)
         GameExecutor.post(newGame) {
             if (player.game !== null) {
                 logger.warn("${player}登录异常")


### PR DESCRIPTION
### 协议修改

https://github.com/CuteReimu/TheMessage/blob/063324fdd679b8e7d18b4c6dfd4cbe4cdf4a7873/src/main/proto/fengsheng.proto#L75-L86

新增notice和room_id字段

### 代码修改

- 不再是游戏开始时才把房间加入`GameCache`，而是在创建房间时就加入
  - 因此房间存在一个`!isStart && !isEnd`的状态，也就是游戏还未开始，在`forceEnd`时需要排除这种状态。`addrobot`的GM命令、`forceend`的GM命令、玩家强退时都需要修改
- 新增房间号逻辑（文件`GameExcutor.kt`的修改）
  - 如果传了房间号
    - 如果房间存在，则直接进入。如果加入失败（人满了）则返回错误。
    - 如果房间不存在，则创建房间并加入。如果创建失败（并发了）或者加入失败则返回错误。
  - 如果没传房间号，则随机找一个已经创建但未开始的房间
    - 如果找到了，则加入。如果加入失败（人满了）则返回错误。
    - 如果没找到，则分配一个房间号。如果创建失败（房间已存在）或者加入失败则返回错误。